### PR TITLE
Implement backend/thunks for EditProduct form (#73, #74)

### DIFF
--- a/client/components/EditProduct.js
+++ b/client/components/EditProduct.js
@@ -1,13 +1,20 @@
 import React from 'react'
 import {ProductForm} from '../components'
+import {updateProductById} from '../store'
+import {connect} from 'react-redux'
 
 class EditProducts extends React.Component {
-  submit = values => {
-    console.log(values)
+  submit = editedProduct => {
+    this.props.updateProductById(editedProduct)
+    this.props.history.push(`/product/${this.props.match.params.productId}`)
   }
   render() {
     return <ProductForm {...this.props} onSubmit={this.submit} />
   }
 }
 
-export default EditProducts
+const mapDispatchToProps = dispatch => ({
+  updateProductById: product => dispatch(updateProductById(product))
+})
+
+export default connect(null, mapDispatchToProps)(EditProducts)

--- a/client/components/SingleProduct.js
+++ b/client/components/SingleProduct.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import {connect} from 'react-redux'
+import {Link} from 'react-router-dom'
 
 class SingleProduct extends React.Component {
   render() {
@@ -13,9 +14,12 @@ class SingleProduct extends React.Component {
             <h6>Qty: {inventory}</h6>
             <p>{description}</p>
             <div className="row">
-              <a className="col s3 waves-effect waves-light btn">
+              <Link
+                to={`${this.props.match.url}/edit`}
+                className="col s3 waves-effect waves-light btn"
+              >
                 Edit Product
-              </a>
+              </Link>
               <a className="col s3 waves-effect waves-light btn">Add to Cart</a>
             </div>
           </div>

--- a/client/store/products.js
+++ b/client/store/products.js
@@ -4,6 +4,7 @@ import history from '../history'
 // ACTION TYPES
 
 const GET_PRODUCTS = 'GET_PRODUCTS'
+const PRODUCT_UPDATED = 'PRODUCT_UPDATED'
 // const REMOVE_USER = 'REMOVE_USER'
 
 /**
@@ -29,6 +30,11 @@ const gotProducts = products => ({
   type: GET_PRODUCTS,
   products
 })
+
+const productUpdated = updatedProduct => ({
+  type: PRODUCT_UPDATED,
+  updatedProduct
+})
 // const removeUser = () => ({type: REMOVE_USER})
 
 // THUNK CREATORS
@@ -39,6 +45,13 @@ export const getProducts = () => dispatch => {
     .get(`/api/products`)
     .then(({data}) => dispatch(gotProducts(data)))
     .catch(error => console.error(error))
+}
+
+export const updateProductById = product => dispatch => {
+  axios
+    .put(`/api/products/${product.id}`, product)
+    .then(({data}) => dispatch(productUpdated(data)))
+    .catch(err => console.error(err))
 }
 
 // REDUCER
@@ -52,6 +65,14 @@ export default function(state = defaultProducts, action) {
           return result
         }, {}),
         allIds: action.products.map(product => product.id)
+      }
+    case PRODUCT_UPDATED:
+      return {
+        byId: {
+          ...state.byId,
+          [action.updatedProduct.id]: action.updatedProduct
+        },
+        allIds: [...state.allIds]
       }
     default:
       return state

--- a/server/api/products.js
+++ b/server/api/products.js
@@ -2,6 +2,15 @@ const router = require('express').Router()
 const {Product} = require('../db/models')
 module.exports = router
 
+// Helper functions to shape database requests.
+const createProductFromJSON = body => ({
+  title: '' + body.title,
+  description: '' + body.description,
+  price: +body.price,
+  imageURL: '' + body.imageURL,
+  inventory: +body.inventory
+})
+
 router.get('/', async (req, res, next) => {
   try {
     const products = await Product.findAll({})
@@ -11,3 +20,19 @@ router.get('/', async (req, res, next) => {
   }
 })
 
+/* TODO: Add isAdmin*/
+router.put('/:productId', (req, res, next) => {
+  if (req.body.id && +req.body.id !== +req.params.productId) {
+    next(new Error('Bad Request detected in PUT /:productId'))
+  } else {
+    Product.update(createProductFromJSON(req.body), {
+      where: {id: +req.params.productId},
+      returning: true
+    })
+      .spread(
+        (done, updatedProd) =>
+          done ? res.json(...updatedProd) : res.status(404).end()
+      )
+      .catch(next)
+  }
+})


### PR DESCRIPTION
This should close #73 and #74 -- editing products on the frontend and the backend.

Note that the SingleProduct component is also updated to link to the EditProduct form, and the EditProduct form will redirect the user to the SingleProduct component after the edit.