### PR TITLE
product with no quantity will not have a add cart option

### DIFF
--- a/client/components/AddToCartButton.js
+++ b/client/components/AddToCartButton.js
@@ -6,20 +6,21 @@ class AddToCartButton extends React.Component {
   // Expects a prodId prop to be give to it from higher order component.
   // Also expects a dumb button that can take an 'add' prop to be given to it.
   add = () => {
-    const {productId, quantity} = this.props
+    const {productId, modifyCartQuantity} = this.props
     if (this.props.isInCart) {
-      this.props.editItemInCart({productId, quantity})
-    } else this.props.addItemToCart({productId, quantity})
+      this.props.editItemInCart({productId, modifyCartQuantity})
+    } else this.props.addItemToCart({productId, modifyCartQuantity})
   }
 
   render() {
     const WrappedButton = this.props.buttonTypeComponent
-    return <WrappedButton add={this.add} />
+    return <WrappedButton add={this.add} productQuantity={this.props.productQuantity}/>
   }
 }
 const mapStateToProps = (state, {productId}) => ({
-  quantity: addToCartQuantity(state.cart, productId),
-  isInCart: !!state.cart.byProductId[productId]
+  modifyCartQuantity: addToCartQuantity(state.cart, productId),
+  isInCart: !!state.cart.byProductId[productId],
+  productQuantity: state.products.byId[productId].inventory
 })
 
 const mapDispatchToProps = dispatch => ({

--- a/client/components/BigAddToCartButton.js
+++ b/client/components/BigAddToCartButton.js
@@ -1,11 +1,13 @@
 import React from 'react'
 
+// console.log('props in the big add', this.props)
 const BigAddToCartButton = props => (
   <button
     className="waves-effect waves-light btn"
     alt="Add to Cart"
     type="button"
     onClick={props.add}
+    disabled={!props.productQuantity}
   >
     Add to Cart
     <i className="material-icons right" alt="Add to cart">


### PR DESCRIPTION
#148 
When there is no product, the add cart button is disabled. Also, I changed the prop name for the quantity of cart in AddToCartButton.js to modifyCartQuantity to make clearer.